### PR TITLE
Add custom xattr driven restrictions for script roots and ws files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ src/test_curl_util
 src/test_string_util
 test/s3proxy-*
 
+.DS_Store
+.vscode
+
 #
 # Local variables:
 # tab-width: 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# Reference: https://github.com/s3fs-fuse/s3fs-fuse/wiki/Installation-Notes
+
+FROM ubuntu:18.04 AS build
+
+ARG SCRIPT_SOURCE_DIR=dockerfile_scripts
+ARG SCRIPT_DEST_DIR=/usr/local/bin
+
+# Install general build tools
+
+RUN apt-get update
+
+RUN apt-get install -y \
+  build-essential \
+  fakeroot \
+  dpkg-dev \
+  devscripts \
+  git \
+  curl \
+;
+
+RUN apt-get install -y s3fs
+
+RUN apt-get install -y \
+    build-essential \
+    git \
+    libfuse-dev \
+    libcurl4-openssl-dev \
+    libxml2-dev \
+    mime-support \
+    automake \
+    libtool \
+    pkg-config \
+    libssl-dev \
+  ;
+
+RUN mkdir /usr/src/build
+COPY . /usr/src/build/s3fs-fuse
+WORKDIR /usr/src/build/s3fs-fuse
+RUN ./autogen.sh
+RUN ./configure
+RUN make
+RUN make install

--- a/builds/build.sh
+++ b/builds/build.sh
@@ -1,0 +1,6 @@
+# docker build . -t build-s3fs
+
+s3fs_path=$(docker run --rm build-s3fs sh -c "which s3fs")
+id=$(docker create build-s3fs)
+docker cp $id:$s3fs_path ./builds/s3fs-$(date '+%Y-%m-%d-%H:%M:%S')
+docker rm -v $id

--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -272,7 +272,6 @@ time_t get_lastmodified(const headers_t& meta)
     return get_lastmodified((*iter).second.c_str());
 }
 
-// Returns if this object is a script root
 bool is_script_root(const headers_t& meta)
 {
     headers_t::const_iterator iter;
@@ -283,7 +282,6 @@ bool is_script_root(const headers_t& meta)
     return false;
 }
 
-// Returns if this object cannot be changed
 bool is_immutable(const headers_t& meta)
 {
     headers_t::const_iterator iter;

--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -272,6 +272,28 @@ time_t get_lastmodified(const headers_t& meta)
     return get_lastmodified((*iter).second.c_str());
 }
 
+// Returns if this object is a script root
+bool is_script_root(const headers_t& meta)
+{
+    headers_t::const_iterator iter;
+    if(meta.end() != (iter = meta.find("x-amz-meta-xattr"))){
+        return (*iter).second.find("\"is_script_root\":true") != std::string::npos;
+    }
+
+    return false;
+}
+
+// Returns if this object cannot be changed
+bool is_immutable(const headers_t& meta)
+{
+    headers_t::const_iterator iter;
+    if(meta.end() != (iter = meta.find("x-amz-meta-xattr"))){
+        return (*iter).second.find("\"editable\":false") != std::string::npos;
+    }
+
+    return false;
+}
+
 //
 // Returns it whether it is an object with need checking in detail.
 // If this function returns true, the object is possible to be directory

--- a/src/metaheader.h
+++ b/src/metaheader.h
@@ -55,6 +55,8 @@ blkcnt_t get_blocks(off_t size);
 time_t cvtIAMExpireStringToTime(const char* s);
 time_t get_lastmodified(const char* s);
 time_t get_lastmodified(const headers_t& meta);
+bool is_script_root(const headers_t& meta);
+bool is_immutable(const headers_t& meta);
 bool is_need_check_obj_detail(const headers_t& meta);
 bool merge_headers(headers_t& base, const headers_t& additional, bool add_noexist);
 bool simple_parse_xml(const char* data, size_t len, const char* key, std::string& value);


### PR DESCRIPTION
Adds logic to support WayScript specific restrictions using xattrs:
- Script roots are unmovable and undeletable
- Special ws files are unmovable and undeletable
- Mkdir is not allowed under a script root

Additionally adds a dockerfile and script for creating a Linux built binary for use in sandbox image. This will be the temporary solution until something like a Debian repo or something more official is established.